### PR TITLE
Reload nginx or stunnel when updating certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.0 (2016-09-24)
+
+  * Reload nginx or stunnel when updating the SSL certificate rather than the admin API
+
 ## 1.11.0 (2016-04-24)
 
   * Source /etc/profile for consistent use of 'tar' command

--- a/group_vars/appliances
+++ b/group_vars/appliances
@@ -10,4 +10,4 @@ picolisp_version: 3.1.11
 picolisp_sha1: e6f1c9227b3dc21f701906567bcbc943dff8c972
 ssh_path: /etc/ssh
 
-jidoteki_admin_version: 1.11.0
+jidoteki_admin_version: 1.12.0

--- a/group_vars/images
+++ b/group_vars/images
@@ -5,4 +5,4 @@ admin_type: LIVE IMAGE
 admin_type_lowcase: live image
 ssh_path: /usr/local/etc/ssh
 
-jidoteki_admin_version: 1.11.0
+jidoteki_admin_version: 1.12.0

--- a/roles/admin/templates/update_certs.sh.j2
+++ b/roles/admin/templates/update_certs.sh.j2
@@ -141,13 +141,13 @@ replace_old_certs     || fail_and_exit
 
 # Restart stunnel, stunnel4 or nginx if they are running
 if pidof nginx >/dev/null; then
-  killall -HUP nginx
+  killall -HUP nginx >/dev/null 2>&1 || true
 fi
 if pidof stunnel >/dev/null; then
-  killall -HUP stunnel
+  killall -HUP stunnel >/dev/null 2>&1 || true
 fi
 if pidof stunnel4 >/dev/null; then
-  killall -HUP stunnel4
+  killall -HUP stunnel4 >/dev/null 2>&1 || true
 fi
 
 

--- a/roles/admin/templates/update_certs.sh.j2
+++ b/roles/admin/templates/update_certs.sh.j2
@@ -139,8 +139,17 @@ generate_ca_bundle    && \
 generate_chained_cert && \
 replace_old_certs     || fail_and_exit
 
-# Restart the Jidoteki Admin API if it exists
-[ -f "/usr/local/etc/init.d/jidoteki-admin-api" ] && /usr/local/etc/init.d/jidoteki-admin-api restart
+# Restart stunnel, stunnel4 or nginx if they are running
+if pidof nginx >/dev/null; then
+  killall -HUP nginx
+fi
+if pidof stunnel >/dev/null; then
+  kilalll -HUP stunnel
+fi
+if pidof stunnel4 >/dev/null; then
+  killall -HUP stunnel4
+fi
+
 
 echo "success" > "${admin_dir}/etc/status_certs.txt"
 echo "[`date +%s`][{{ admin_type }}] Add TLS certificates successful" 2>&1 | tee -a "${admin_dir}/log/update_certs.log"

--- a/roles/admin/templates/update_certs.sh.j2
+++ b/roles/admin/templates/update_certs.sh.j2
@@ -144,7 +144,7 @@ if pidof nginx >/dev/null; then
   killall -HUP nginx
 fi
 if pidof stunnel >/dev/null; then
-  kilalll -HUP stunnel
+  killall -HUP stunnel
 fi
 if pidof stunnel4 >/dev/null; then
   killall -HUP stunnel4

--- a/roles/admin/templates/update_certs.sh.j2
+++ b/roles/admin/templates/update_certs.sh.j2
@@ -115,6 +115,8 @@ replace_old_certs() {
   mv -f enterprise.crt /usr/local/etc/pki/tls/certs/
   mv -f enterprise.pem /usr/local/etc/pki/tls/
 
+  ln -sf /usr/local/etc/pki/tls/enterprise.pem /enterprise.pem # symlink for stunnel HUP
+
   if [ -f "enterprise-ca.crt" ]; then
     chmod 0640 enterprise-ca.crt
     chown root:staff enterprise-ca.crt


### PR DESCRIPTION
Instead of reloading the admin API.  Closes issue #15.
