### PR TITLE
Merge jidometa-scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ cache: apt
 dist: precise
 
 before_script:
-  - sudo apt-get install picolisp
-  - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz
+  - wget http://software-lab.de/picoLisp-16.6.tgz -O /tmp/picolisp.tgz
   - cd /tmp; tar -xf /tmp/picolisp.tgz
   - cd /tmp/picoLisp/src64 && make
-  - pip install ansible==1.8.4
+  - export PATH=$PATH:/tmp/picoLisp
+  - sudo pip install ansible==1.8.4
 
 script:
   - export PATH=$PATH:/tmp/picoLisp

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
 
 script:
   - export PATH=$PATH:/tmp/picoLisp
-  - cd ${TRAVIS_BUILD_DIR} && make check
+  - cd ${TRAVIS_BUILD_DIR} && make check PREFIX_DIR=/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz
   - cd /tmp; tar -xf /tmp/picolisp.tgz
   - cd /tmp/picoLisp/src64 && make
+  - pip install ansible==1.8.4
 
 script:
   - export PATH=$PATH:/tmp/picoLisp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: apt
 dist: precise
 
 before_script:
+  - apt-get install picolisp
   - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz
   - cd /tmp; tar -xf /tmp/picolisp.tgz
   - cd /tmp/picoLisp/src64 && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: apt
 dist: precise
 
 before_script:
-  - apt-get install picolisp
+  - sudo apt-get install picolisp
   - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz
   - cd /tmp; tar -xf /tmp/picolisp.tgz
   - cd /tmp/picoLisp/src64 && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: bash
+sudo: false
+cache: apt
+
+before_script:
+  - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz
+  - cd /tmp; tar -xf /tmp/picolisp.tgz
+  - cd /tmp/picoLisp/src64 && make
+
+script:
+  - export PATH=$PATH:/tmp/picoLisp
+  - cd ${TRAVIS_BUILD_DIR} && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
 
 script:
   - export PATH=$PATH:/tmp/picoLisp
-  - cd ${TRAVIS_BUILD_DIR} && make check PREFIX_DIR=/tmp
+  - cd ${TRAVIS_BUILD_DIR} && make check PREFIX_DIR=/tmp/meta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: bash
-sudo: false
+sudo: required
 cache: apt
+dist: precise
 
 before_script:
   - wget http://software-lab.de/picoLisp-17.12.tgz -O /tmp/picolisp.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.20.0 (2018-02-04)
+
+  * Merge 'jidometa-scripts' repo into this one
+  * Add Travis tests for tc-functions helpers
+
 ## 1.19.0 (2017-12-17)
 
   * Dry-run stunnel to check for valid TLS certs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0 (2018-02-04)
 
+  * Update process uses fixed disk temporarily, reduces memory requirement for update packages
   * Merge 'jidometa-scripts' repo into this one
   * Add Travis tests for tc-functions helpers
   * Renamed 'Jidoteki' to 'On-Prem'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
   * Merge 'jidometa-scripts' repo into this one
   * Add Travis tests for tc-functions helpers
+  * Renamed 'Jidoteki' to 'On-Prem'
 
 ## 1.19.0 (2017-12-17)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2013-2017 Alexander Williams, Unscramble <license@unscramble.jp>
+Copyright (c) 2013-2018 Alexander Williams, Unscramble <license@unscramble.jp>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: all check run-tests
 
 all:
-		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s -vvvv
+		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s -v
 
 check: all run-tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# tinycore-scripts Makefile
+# Jidoteki Admin Makefile
 
 PIL_MODULE_DIR ?= .modules
 REPO_PREFIX ?= https://github.com/aw
@@ -21,6 +21,7 @@ TEST_REF ?= v2.1.0
 .PHONY: all check run-tests
 
 all:
+		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s
 
 $(JSON_DIR):
 		mkdir -p $(JSON_DIR) && \

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,11 @@
 # Jidoteki Admin Makefile
 
-PIL_MODULE_DIR ?= .modules
-REPO_PREFIX ?= https://github.com/aw
-
-JSON_REPO = $(REPO_PREFIX)/picolisp-json.git
-JSON_DIR = $(PIL_MODULE_DIR)/picolisp-json/HEAD
-JSON_REF ?= v3.2.0
-
-SEMVER_REPO = $(REPO_PREFIX)/picolisp-semver.git
-SEMVER_DIR = $(PIL_MODULE_DIR)/picolisp-semver/HEAD
-SEMVER_REF ?= v0.10.0
-
-# Unit testing
-TEST_REPO = $(REPO_PREFIX)/picolisp-unit.git
-TEST_DIR = $(PIL_MODULE_DIR)/picolisp-unit/HEAD
-TEST_REF ?= v2.1.0
-
-# Generic
-
 .PHONY: all check run-tests
 
 all:
 		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s
 
-$(JSON_DIR):
-		mkdir -p $(JSON_DIR) && \
-		git clone $(JSON_REPO) $(JSON_DIR) && \
-		cd $(JSON_DIR) && \
-		git checkout $(JSON_REF)
-
-$(SEMVER_DIR):
-		mkdir -p $(SEMVER_DIR) && \
-		git clone $(SEMVER_REPO) $(SEMVER_DIR) && \
-		cd $(SEMVER_DIR) && \
-		git checkout $(SEMVER_REF)
-
-$(TEST_DIR):
-		mkdir -p $(TEST_DIR) && \
-		git clone $(TEST_REPO) $(TEST_DIR) && \
-		cd $(TEST_DIR) && \
-		git checkout $(TEST_REF)
-
-check: $(JSON_DIR) $(SEMVER_DIR) $(TEST_DIR) run-tests
+check: all run-tests
 
 run-tests:
-		TC_LIB_PATH=$(shell pwd) PIL_NAMESPACES=false ./test.l
+		JIDO_ADMIN_PATH=$(PREFIX_DIR)/opt/jidoteki/tinyadmin PIL_NAMESPACES=false ./test.l

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# tinycore-scripts Makefile
+
+PIL_MODULE_DIR ?= .modules
+REPO_PREFIX ?= https://github.com/aw
+
+JSON_REPO = $(REPO_PREFIX)/picolisp-json.git
+JSON_DIR = $(PIL_MODULE_DIR)/picolisp-json/HEAD
+JSON_REF ?= v3.2.0
+
+SEMVER_REPO = $(REPO_PREFIX)/picolisp-semver.git
+SEMVER_DIR = $(PIL_MODULE_DIR)/picolisp-semver/HEAD
+SEMVER_REF ?= v0.10.0
+
+# Unit testing
+TEST_REPO = $(REPO_PREFIX)/picolisp-unit.git
+TEST_DIR = $(PIL_MODULE_DIR)/picolisp-unit/HEAD
+TEST_REF ?= v2.1.0
+
+# Generic
+
+.PHONY: all check run-tests
+
+all:
+
+$(JSON_DIR):
+		mkdir -p $(JSON_DIR) && \
+		git clone $(JSON_REPO) $(JSON_DIR) && \
+		cd $(JSON_DIR) && \
+		git checkout $(JSON_REF)
+
+$(SEMVER_DIR):
+		mkdir -p $(SEMVER_DIR) && \
+		git clone $(SEMVER_REPO) $(SEMVER_DIR) && \
+		cd $(SEMVER_DIR) && \
+		git checkout $(SEMVER_REF)
+
+$(TEST_DIR):
+		mkdir -p $(TEST_DIR) && \
+		git clone $(TEST_REPO) $(TEST_DIR) && \
+		cd $(TEST_DIR) && \
+		git checkout $(TEST_REF)
+
+check: $(JSON_DIR) $(SEMVER_DIR) $(TEST_DIR) run-tests
+
+run-tests:
+		TC_LIB_PATH=$(shell pwd) PIL_NAMESPACES=false ./test.l

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ all:
 check: all run-tests
 
 run-tests:
-		JIDO_ADMIN_PATH=$(PREFIX_DIR)/opt/jidoteki/tinyadmin PIL_NAMESPACES=false ./test.l
+		JIDO_ADMIN_PATH=$(PREFIX_DIR)/opt/jidoteki/tinyadmin ./test.l

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: all check run-tests
 
 all:
-		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s
+		ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=$(PREFIX_DIR) --tags=admin -s -vvvv
 
 check: all run-tests
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains bash scripts, ansible roles, and other files needed to 
 * curl
 * git
 * sha1sum (from core-utils)
-* [symlinktool](https://github.com/aw/tinycore-symlinktool) for running backups
+* [symlinktool](https://github.com/on-prem/tinycore-symlinktool) for running backups
 * [openssl](https://openssl.org/) v1.0.2+, for validating TLS certs
 * [stunnel](https://www.stunnel.org) for validating TLS certs
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Jidoteki virtual appliance & live image administration
+# On-Prem virtual appliance & live image administration
 
-[![GitHub release](https://img.shields.io/github/release/unscramble/jidoteki-admin.svg)](https://jidoteki.com) [![Build Status](https://travis-ci.org/unscramble/jidoteki-admin.svg?branch=master)](https://travis-ci.org/unscramble/jidoteki-admin)  [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--semver-v0.10.0-ff69b4.svg)](https://github.com/aw/picolisp-semver) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--json-v3.2.0-ff69b4.svg)](https://github.com/aw/picolisp-json) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--unit-v2.1.0-ff69b4.svg)](https://github.com/aw/picolisp-unit.git)
+[![GitHub release](https://img.shields.io/github/release/on-prem/jidoteki-admin.svg)](https://on-premises.com) [![Build Status](https://travis-ci.org/on-prem/jidoteki-admin.svg?branch=master)](https://travis-ci.org/on-prem/jidoteki-admin)  [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--semver-v0.10.0-ff69b4.svg)](https://github.com/aw/picolisp-semver) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--json-v3.2.0-ff69b4.svg)](https://github.com/aw/picolisp-json) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--unit-v2.1.0-ff69b4.svg)](https://github.com/aw/picolisp-unit.git)
 
-[Jidoteki](https://jidoteki.com) installs the `Jidoteki Admin` package in `/opt/jidoteki`.
+[On-Prem](https://on-premises.com) installs the `On-Prem Admin` package in `/opt/jidoteki`.
 
 This repository contains bash scripts, ansible roles, and other files needed to perform remote virtual appliance or live image administration, updates, etc.
 
@@ -27,8 +27,8 @@ ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=<destdir> -
 
 There exist two `tags` for running the ansible roles:
 
-  - **admin**: executes every task in the role, installing all Jidoteki Admin scripts
-  - **lib**: only executes tasks related to the lib dependencies, without the Jidoteki Admin scripts
+  - **admin**: executes every task in the role, installing all On-Prem Admin scripts
+  - **lib**: only executes tasks related to the lib dependencies, without the On-Prem Admin scripts
 
 ### admin role
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Jidoteki virtual appliance & live image administration
 
-[![GitHub release](https://img.shields.io/github/release/unscramble/jidoteki-admin.svg)](https://jidoteki.com)
+[![GitHub release](https://img.shields.io/github/release/unscramble/jidoteki-admin.svg)](https://jidoteki.com) [![Build Status](https://travis-ci.org/unscramble/jidoteki-admin.svg?branch=master)](https://travis-ci.org/unscramble/jidoteki-admin)  [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--semver-v0.10.0-ff69b4.svg)](https://github.com/aw/picolisp-semver) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--json-v3.2.0-ff69b4.svg)](https://github.com/aw/picolisp-json) [![Dependency](https://img.shields.io/badge/[deps]&#32;picolisp--unit-v2.1.0-ff69b4.svg)](https://github.com/aw/picolisp-unit.git)
 
 [Jidoteki](https://jidoteki.com) installs the `Jidoteki Admin` package in `/opt/jidoteki`.
 
 This repository contains bash scripts, ansible roles, and other files needed to perform remote virtual appliance or live image administration, updates, etc.
 
-## Requirements
+# Requirements
 
 * Ansible 1.5.x
 * curl
@@ -16,17 +16,23 @@ This repository contains bash scripts, ansible roles, and other files needed to 
 * [openssl](https://openssl.org/) v1.0.2+, for validating TLS certs
 * [stunnel](https://www.stunnel.org) for validating TLS certs
 
-## Ansible roles
+# Usage
 
-There is 1 role executed:
+```
+# replace <destdir> with the directory prefix to install the files
+ansible-playbook jidoteki.yml -c local -i images.inventory -e prefix=<destdir> --tags=admin
+```
 
-  - admin
+### tags
+
+There exist two `tags` for running the ansible roles:
+
+  - **admin**: executes every task in the role, installing all Jidoteki Admin scripts
+  - **lib**: only executes tasks related to the lib dependencies, without the Jidoteki Admin scripts
 
 ### admin role
 
-The `admin` configures directories and files in `/opt/jidoteki/admin` or `/opt/jidoteki/tinyadmin`.
-
-Here is what the `admin` role does:
+The `admin` role configures directories and files in `/opt/jidoteki/tinyadmin`:
 
   * Create admin directory structure
   * Create admin directories writeable by root/admin
@@ -34,6 +40,10 @@ Here is what the `admin` role does:
   * Add SSH admin management scripts
   * Add SSH admin wrapper script
   * Add SSH admin lib dependencies
+
+# Tests
+
+To run the tests, type `make check`
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains bash scripts, ansible roles, and other files needed to 
 
 * Ansible 1.5.x
 * curl
+* git
 * sha1sum (from core-utils)
 * [symlinktool](https://github.com/aw/tinycore-symlinktool) for running backups
 * [openssl](https://openssl.org/) v1.0.2+, for validating TLS certs
@@ -32,6 +33,7 @@ Here is what the `admin` role does:
   * Create admin sftp uploads directory
   * Add SSH admin management scripts
   * Add SSH admin wrapper script
+  * Add SSH admin lib dependencies
 
 # Changelog
 

--- a/group_vars/images
+++ b/group_vars/images
@@ -5,4 +5,15 @@ admin_type: LIVE IMAGE
 admin_type_lowcase: live image
 ssh_path: /usr/local/etc/ssh
 
-jidoteki_admin_version: 1.19.0
+jidoteki_admin_version: 1.20.0
+
+jidoteki_lib_deps:
+  - repo: https://github.com/aw/picolisp-json.git
+    dir: .modules/picolisp-json/HEAD
+    ref: v3.2.0
+  - repo: https://github.com/aw/picolisp-semver.git
+    dir: .modules/picolisp-semver/HEAD
+    ref: v0.10.0
+  - repo: https://github.com/aw/picolisp-unit.git
+    dir: .modules/picolisp-unit/HEAD
+    ref: v2.1.0

--- a/images.inventory
+++ b/images.inventory
@@ -1,2 +1,2 @@
 [images]
-images ansible_python_interpreter=/usr/local/bin/python
+images

--- a/roles/admin/tasks/main.yml
+++ b/roles/admin/tasks/main.yml
@@ -110,6 +110,17 @@
     mode=0755
     recurse=yes
   with_items:
-    - {{ jidoteki_lib_deps }}
+    - "{{ jidoteki_lib_deps }}"
+  tags:
+    - skip
+
+- name: Add SSH admin library deps files
+  shell: |
+    chdir={{ prefix }}{{ admin_path }}/lib
+    git clone {{ item.repo }} {{ item.dir }} && \
+    cd {{ item.dir }} && \
+    git checkout {{ item.ref }}
+  with_items:
+    - "{{ jidoteki_lib_deps }}"
   tags:
     - admin

--- a/roles/admin/tasks/main.yml
+++ b/roles/admin/tasks/main.yml
@@ -101,25 +101,11 @@
   tags:
     - admin
 
-- name: Add SSH admin library deps dirs
-  file: >
-    state=directory
-    path={{ prefix }}{{ admin_path }}/lib/{{ item.dir }}
-    owner=0
-    group=0
-    mode=0755
-    recurse=yes
-  with_items:
-    - "{{ jidoteki_lib_deps }}"
-  tags:
-    - skip
-
-- name: Add SSH admin library deps files
-  shell: |
-    chdir={{ prefix }}{{ admin_path }}/lib
-    git clone {{ item.repo }} {{ item.dir }} && \
-    cd {{ item.dir }} && \
-    git checkout {{ item.ref }}
+- name: Add SSH admin library deps
+  git: >
+    dest={{ prefix }}{{ admin_path }}/lib/{{ item.dir }}
+    repo={{ item.repo }}
+    version={{ item.ref }}
   with_items:
     - "{{ jidoteki_lib_deps }}"
   tags:

--- a/roles/admin/tasks/main.yml
+++ b/roles/admin/tasks/main.yml
@@ -2,6 +2,23 @@
 #
 # user/group 998 = sftpadmin, 997 = admin, 50 = staff, 0 = root
 
+- name: Create admin directory structure
+  file: >
+    state=directory
+    path={{ prefix }}{{ item }}
+    owner=0
+    group=0
+    mode=0755
+  with_items:
+    - "{{ admin_path }}"
+    - "{{ admin_path }}/bin"
+    - "{{ admin_path }}/tmp"
+    - "{{ admin_path }}/lib"
+    - "{{ admin_path }}/home/sftp"
+  tags:
+    - admin
+    - lib
+
 - name: Create admin home directories
   file: >
     state=directory
@@ -15,22 +32,6 @@
     - "{{ admin_path }}/home/.ssh"
   tags:
     - admin
-
-- name: Create admin directory structure
-  file: >
-    state=directory
-    path={{ prefix }}{{ item }}
-    owner=0
-    group=0
-    mode=0755
-  with_items:
-    - "{{ admin_path }}/bin"
-    - "{{ admin_path }}/tmp"
-    - "{{ admin_path }}/lib"
-    - "{{ admin_path }}/home/sftp"
-  tags:
-    - admin
-    - lib
 
 - name: Create admin sftp uploads directory
   file: >

--- a/roles/admin/tasks/main.yml
+++ b/roles/admin/tasks/main.yml
@@ -26,6 +26,7 @@
   with_items:
     - "{{ admin_path }}/bin"
     - "{{ admin_path }}/tmp"
+    - "{{ admin_path }}/lib"
     - "{{ admin_path }}/home/sftp"
   tags:
     - admin
@@ -85,5 +86,30 @@
     owner=0
     group=997
     mode=0750
+  tags:
+    - admin
+
+- name: Add SSH admin library scripts
+  template: >
+    src={{ item }}.j2
+    dest="{{ prefix }}{{ admin_path }}/lib/{{ item }}"
+    owner=0
+    group=0
+    mode=0644
+  with_items:
+    - tc-functions.l
+  tags:
+    - admin
+
+- name: Add SSH admin library deps dirs
+  file: >
+    state=directory
+    path={{ prefix }}{{ admin_path }}/lib/{{ item.dir }}
+    owner=0
+    group=0
+    mode=0755
+    recurse=yes
+  with_items:
+    - {{ jidoteki_lib_deps }}
   tags:
     - admin

--- a/roles/admin/tasks/main.yml
+++ b/roles/admin/tasks/main.yml
@@ -30,6 +30,7 @@
     - "{{ admin_path }}/home/sftp"
   tags:
     - admin
+    - lib
 
 - name: Create admin sftp uploads directory
   file: >
@@ -100,6 +101,7 @@
     - tc-functions.l
   tags:
     - admin
+    - lib
 
 - name: Add SSH admin library deps
   git: >
@@ -110,3 +112,4 @@
     - "{{ jidoteki_lib_deps }}"
   tags:
     - admin
+    - lib

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -11,7 +11,7 @@
 
 (setq
   *Root "/"
-  *Tc_lib_path  (if (sys "TC_LIB_PATH") @ "/opt/jidoteki/tinyadmin/lib")
+  *Tc_lib_path  (pack (if (sys "JIDO_ADMIN_PATH") @ "/opt/jidoteki/tinyadmin") "/lib")
   *Semver_lib   (pack *Tc_lib_path "/.modules/picolisp-semver/HEAD/semver.l")
   *Json_lib     (pack *Tc_lib_path "/.modules/picolisp-json/HEAD/json.l") )
 

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -9,6 +9,8 @@
 #   All functions must be prefixed with tc-, to prevent clashes with existing code / libraries
 #   (exception for (colour) and (error-codes), which can be overwritten by other implementations
 
+(sys "PIL_NAMESPACES" "false")
+
 (setq
   *Root "/"
   *Tc_lib_path  (pack (if (sys "JIDO_ADMIN_PATH") @ "/opt/jidoteki/tinyadmin") "/lib")

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -200,10 +200,10 @@
 ### External libraries
 
 # SemVer library
-(when (info *Semver_lib) (err "/dev/null" (load *Semver_lib)))
+(when (info *Semver_lib) (undef 'MODULE_INFO) (err "/dev/null" (load *Semver_lib)))
 
 # JSON library
-(when (info *Json_lib) (err "/dev/null" (load *Json_lib)))
+(when (info *Json_lib) (undef 'MODULE_INFO) (err "/dev/null" (load *Json_lib)))
 
 # use this variable to verify if the above functions have been loaded or not
 (setq *Tc_functions_loaded T)

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -1,0 +1,194 @@
+# Generic functions
+#
+# Copyright (c) 2016-2018 Alex Williams, Unscramble. See the LICENSE file (MIT).
+# https://unscramble.co.jp
+#
+# VERSION: {{ jidoteki_admin_version }}
+
+(setq
+  *Root "/"
+  *Tc_lib_path  (if (sys "TC_LIB_PATH") @ "/opt/jidoteki/tinyadmin/lib")
+  *Semver_lib   (pack *Tc_lib_path "/.modules/picolisp-semver/HEAD/semver.l")
+  *Json_lib     (pack *Tc_lib_path "/.modules/picolisp-json/HEAD/json.l") )
+
+(de *Colours
+  ("red"      . 1)
+  ("green"    . 2)
+  ("yellow"   . 3)
+  ("blue"     . 4)
+  ("magenta"  . 5)
+  ("cyan"     . 6)
+  ("white"    . 7) )
+
+(seed (in "/dev/urandom" (rd 20)))
+
+### Internal
+
+# colourizes the console
+# returns NIL in all cases
+[de colour (Colour)
+  (err "/dev/null"
+    (let Col (lowc Colour)
+      (cond ((assoc Col *Colours) (call 'tput "bold") (call 'tput "setaf" (cdr @)))
+            ((= Col "bold")       (call 'tput "bold"))
+            ((= Col "clear")      (call 'clear))
+            ((= Col "cursor")     (call 'tput "cvvis"))
+            ((= Col "nocursor")   (call 'tput "civis"))
+            (T                    (call 'tput "sgr0")) ) )
+    NIL ]
+
+[de color @ (pass colour) ] # for Americans
+
+[de error-codes
+  ("TC0001" "Missing command line arguments")
+  ("TC0002" "Invalid command line option") ]
+
+[de tc-error (Code Details)
+  (let Error (assoc Code error-codes)
+    (list (cons "File"    (cadr (file)))
+          (cons "Code"    (car Error))
+          (cons "Message" (cadr Error))
+          (cons "Details" Details) ]
+
+(de tc-split-value (Value Separator)
+    (mapcar pack
+            (split (chop Value) Separator) ) )
+
+(de tc-parse-options (Options)
+    (mapcar '((N) (tc-split-value N "="))
+            (tc-split-value Options " ") ) )
+
+(de tc-getparam (Param Options)
+    (cadr (assoc Param (tc-parse-options Options))) )
+
+[de tc-version ()
+  (pack (cdr (assoc "name" APP_INFO)) " v"
+        (cdr (assoc "version" APP_INFO)) "^J"
+        "Copyright "
+        (cdr (assoc "copyright" APP_INFO)) "^J"
+        "License "
+        (cdr (assoc "license" APP_INFO)) ]
+
+[de tc-summary ()
+  (pack "^J"
+        (cdr (assoc "summary" APP_INFO)) "^J"
+        (cdr (assoc "source" APP_INFO)) "^J"
+        "^JUsage:^I^I"
+        (cdr (assoc "usage" APP_HELP)) "^J"
+        "^JExample:^I"
+        (cdr (assoc "example" APP_HELP)) "^J^J"
+        "Options:" ]
+
+[de tc-options (N)
+  (tab  (2 -10 5)
+        " "
+        (car N)
+        (cdr N) ]
+
+[de tc-error-stderr (Error)
+  (out 2
+    (prinl (glue ": " (extract cdr Error))) ]
+
+[de tc-error-generic (Error)
+  (out 2
+    (prinl Error) ]
+
+[de tc-error-output (Error)
+  (case (sys "TC_OUTPUT_TYPE")
+        ("json"   (tc-error-generic (encode Error)))
+        (T        (tc-error-stderr Error) ]
+
+(de tc-show-version ()
+  (prinl (tc-version)) )
+
+(de tc-show-summary ()
+  (prinl (tc-summary)) )
+
+[de tc-show-options ()
+  (mapcar tc-options (cdr (assoc "options" APP_HELP))) ]
+
+### Public
+
+(de getbootparam (Param Cmdline)
+    (tc-getparam Param Cmdline) )
+
+(de checkbootparam (Param Cmdline)
+    (when (assoc Param (tc-parse-options Cmdline))
+          T ) )
+
+(de tc-stderr (Code Details)
+  (tc-error-output (tc-error Code Details))
+  (bye 65) )
+
+[de tc-show-help ()
+  (tc-show-version)
+  (tc-show-summary)
+  (tc-show-options) ]
+
+[de tc-opts (Noargs?)
+  (unless (or (argv) Noargs?) (tc-show-help) (bye))
+  (mapcar '((N)
+            (case N
+                  (--version  (tc-show-version) (bye))
+                  (--help     (tc-show-help) (bye)) ) )
+          (argv) ]
+
+[de tc-validate-option (Arg Num)
+  (unless Num (tc-stderr "TC0002" Arg))
+
+  (if (< (size (argv)) Num)
+      (tc-stderr "TC0001" (pack Arg " <arg1>" (when (> Num 1) (pack " .. <arg" Num ">"))))
+      (make (link Arg) (do Num (link (opt)))) ]
+
+[de tc-getopts (Options)
+  (tc-opts)
+  (make
+    (while  (opt)
+            (link (tc-validate-option @ (cdr (assoc @ Options))) ]
+
+# pipes Msg to Cmd, returns T if no error
+[de tc-call (Cmd Msg)
+  (pipe (err NIL (out Cmd (prin Msg)))
+    (unless (line) T) ]
+
+# pipes STDERR to STDOUT (one line only)
+[de tc-2>&1 (Cmd)
+  (pipe (err NIL (in Cmd (prinl (line T))))
+    (line T) ]
+
+# returns (T . Result) if STDOUT, (NIL . Result) if STDERR
+[de tc-stdouterr (Cmd)
+  (let Rand (tmp "stderr" (rand))
+    (if (info Rand)
+        (tc-stdouterr Cmd))
+        (let Result
+          (if (err Rand (in Cmd (line T)))
+              (cons T @)
+              (cons NIL (in Rand (line T))) )
+          (call 'rm "-f" Rand)
+          Result ]
+
+# tails N lines of a multi-line file and replaces ^J with \\n
+[de tc-multiline (Lines File)
+  (when (info File)
+        (in (list 'tail "-n" Lines File) (pack (replace (till (eof)) "^J" "\\n") ]
+
+# get the process ID from a string
+[de tc-pid (String)
+  (pack
+    (clip
+      (in
+        '(ps "-o" "comm,pid")
+        (from String)
+        (till " ")
+        (line) ]
+
+### External libraries
+
+# SemVer library
+(when (info *Semver_lib) (err "/dev/null" (load *Semver_lib)))
+
+# JSON library
+(when (info *Json_lib) (err "/dev/null" (load *Json_lib)))
+
+(setq *Tc_functions_loaded T)

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -4,6 +4,10 @@
 # https://unscramble.co.jp
 #
 # VERSION: {{ jidoteki_admin_version }}
+#
+# NOTE:
+#   All functions must be prefixed with tc-, to prevent clashes with existing code / libraries
+#   (exception for (colour) and (error-codes), which can be overwritten by other implementations
 
 (setq
   *Root "/"
@@ -23,21 +27,6 @@
 (seed (in "/dev/urandom" (rd 20)))
 
 ### Internal
-
-# colourizes the console
-# returns NIL in all cases
-[de colour (Colour)
-  (err "/dev/null"
-    (let Col (lowc Colour)
-      (cond ((assoc Col *Colours) (call 'tput "bold") (call 'tput "setaf" (cdr @)))
-            ((= Col "bold")       (call 'tput "bold"))
-            ((= Col "clear")      (call 'clear))
-            ((= Col "cursor")     (call 'tput "cvvis"))
-            ((= Col "nocursor")   (call 'tput "civis"))
-            (T                    (call 'tput "sgr0")) ) )
-    NIL ]
-
-[de color @ (pass colour) ] # for Americans
 
 [de error-codes
   ("TC0001" "Missing command line arguments")
@@ -109,22 +98,43 @@
 
 ### Public
 
-(de getbootparam (Param Cmdline)
+# colourizes the console
+# returns NIL in all cases
+[de colour (Colour)
+  (err "/dev/null"
+    (let Col (lowc Colour)
+      (cond ((assoc Col *Colours) (call 'tput "bold") (call 'tput "setaf" (cdr @)))
+            ((= Col "bold")       (call 'tput "bold"))
+            ((= Col "clear")      (call 'clear))
+            ((= Col "cursor")     (call 'tput "cvvis"))
+            ((= Col "nocursor")   (call 'tput "civis"))
+            (T                    (call 'tput "sgr0")) ) )
+    NIL ]
+
+# for Americans
+[de color @ (pass colour) ]
+
+# obtain the value of a boot parameter, example: init=/sbin/init, returns /sbin/init
+(de tc-getbootparam (Param Cmdline)
     (tc-getparam Param Cmdline) )
 
-(de checkbootparam (Param Cmdline)
+# returns T if a boot parameter is set, NIL if it's not
+(de tc-checkbootparam (Param Cmdline)
     (when (assoc Param (tc-parse-options Cmdline))
           T ) )
 
+# outputs an error message and its details to STDERR
 (de tc-stderr (Code Details)
   (tc-error-output (tc-error Code Details))
   (bye 65) )
 
+# outputs an app's version, summary, and options to STDOUT using data from APP_INFO and APP_HELP
 [de tc-show-help ()
   (tc-show-version)
   (tc-show-summary)
   (tc-show-options) ]
 
+# parses the command line options and outputs the result to STDOUT
 [de tc-opts (Noargs?)
   (unless (or (argv) Noargs?) (tc-show-help) (bye))
   (mapcar '((N)
@@ -133,6 +143,7 @@
                   (--help     (tc-show-help) (bye)) ) )
           (argv) ]
 
+# validates a command line option to ensure it contains the correct number of arguments
 [de tc-validate-option (Arg Num)
   (unless Num (tc-stderr "TC0002" Arg))
 
@@ -140,6 +151,7 @@
       (tc-stderr "TC0001" (pack Arg " <arg1>" (when (> Num 1) (pack " .. <arg" Num ">"))))
       (make (link Arg) (do Num (link (opt)))) ]
 
+# parses the command line options and validates the additional arguments
 [de tc-getopts (Options)
   (tc-opts)
   (make
@@ -191,4 +203,5 @@
 # JSON library
 (when (info *Json_lib) (err "/dev/null" (load *Json_lib)))
 
+# use this variable to verify if the above functions have been loaded or not
 (setq *Tc_functions_loaded T)

--- a/roles/admin/templates/tc-functions.l.j2
+++ b/roles/admin/templates/tc-functions.l.j2
@@ -105,12 +105,12 @@
 [de colour (Colour)
   (err "/dev/null"
     (let Col (lowc Colour)
-      (cond ((assoc Col *Colours) (call 'tput "bold") (call 'tput "setaf" (cdr @)))
-            ((= Col "bold")       (call 'tput "bold"))
+      (cond ((assoc Col *Colours) (call '/usr/local/bin/tput "bold") (call '/usr/local/bin/tput "setaf" (cdr @)))
+            ((= Col "bold")       (call '/usr/local/bin/tput "bold"))
             ((= Col "clear")      (call 'clear))
-            ((= Col "cursor")     (call 'tput "cvvis"))
-            ((= Col "nocursor")   (call 'tput "civis"))
-            (T                    (call 'tput "sgr0")) ) )
+            ((= Col "cursor")     (call '/usr/local/bin/tput "cvvis"))
+            ((= Col "nocursor")   (call '/usr/local/bin/tput "civis"))
+            (T                    (call '/usr/local/bin/tput "sgr0")) ) )
     NIL ]
 
 # for Americans

--- a/roles/admin/templates/update_vm.sh.j2
+++ b/roles/admin/templates/update_vm.sh.j2
@@ -2,7 +2,7 @@
 #
 # Generic script for updating a {{ admin_type_lowcase }}
 #
-# Copyright (c) 2013-2016 Alex Williams, Unscramble. See the LICENSE file (MIT).
+# Copyright (c) 2013-2018 Alex Williams, Unscramble. See the LICENSE file (MIT).
 # http://unscramble.co.jp
 #
 # VERSION: {{ jidoteki_admin_version }}
@@ -15,6 +15,7 @@ tar_cmd=`which tar`
 openssl_cmd=`which openssl`
 sort_cmd=`which sort`
 admin_dir="{{ admin_path }}"
+disk_dir="/mnt/sda1"
 uploads_dir="${admin_dir}/home/sftp/uploads"
 update_log="${admin_dir}/log/update.log"
 percentage=0
@@ -42,8 +43,10 @@ log_error() {
 cleanup() {
   cd "${admin_dir}/tmp"
 
-  rm -rf software_package* update extracted
+  rm -rf software_package* update ${disk_dir}/tmp/extracted
   rm -f /tmp/update_vm.sh.task
+  [ -f "${uploads_dir}/${latest_package}" ] && rm -f "${uploads_dir}/${latest_package}"
+  true
 }
 
 update_status() {
@@ -81,23 +84,30 @@ decrypt_software_package() {
   percentage=30
   update_status "running"
 
-  cd "${admin_dir}/tmp"
+  [ -d "${disk_dir}/tmp" ] || mkdir ${disk_dir}/tmp
+  [ -d "${disk_dir}/tmp/extracted" ] || mkdir ${disk_dir}/tmp/extracted
+  [ -d "${admin_dir}/tmp/update" ] || mkdir ${admin_dir}/tmp/update
 
-  [ -d "update" ] || mkdir update
-  [ -d "extracted" ] || mkdir extracted
+  cd "${disk_dir}/tmp"
 
   umask 027
-  mv -f "${uploads_dir}/${latest_package}" "${admin_dir}/tmp/"
-  { $openssl_cmd aes-256-cbc -d -pass file:"${admin_dir}/etc/updates.key" -in "$latest_package" | $tar_cmd -xf - -C extracted; } || log_error "Error decrypting software update package" "E1005"
+  # decrypt and extract to fixed disk
+  { $openssl_cmd aes-256-cbc -d -pass file:"${admin_dir}/etc/updates.key" -in "${uploads_dir}/${latest_package}" | $tar_cmd -xf - -C extracted; } || log_error "Error decrypting software update package" "E1005"
   percentage=40
   update_status "running"
 
-  rm -f "$latest_package"
+  # remove package from memory
+  rm -f "${uploads_dir}/${latest_package}"
+
+  # verify signature
   $openssl_cmd dgst -sha256 -verify "${admin_dir}/etc/updates.pub" -signature extracted/software_package.tar.gz.sign extracted/software_package.tar.gz  || log_error "Error verifying software update package signature" "E1005"
   percentage=50
   update_status "running"
 
-  $tar_cmd --no-same-owner --no-same-permissions -zxf extracted/software_package.tar.gz -C update || log_error "Error extracting software update package" "E1005"
+  # extract contents to memory
+  $tar_cmd --no-same-owner --no-same-permissions -zxf extracted/software_package.tar.gz -C ${admin_dir}/tmp/update || log_error "Error extracting software update package" "E1005"
+
+  # remove contents from fixed disk
   rm -rf extracted
 }
 

--- a/roles/admin/templates/update_vm.sh.j2
+++ b/roles/admin/templates/update_vm.sh.j2
@@ -17,13 +17,15 @@ sort_cmd=`which sort`
 admin_dir="{{ admin_path }}"
 uploads_dir="${admin_dir}/home/sftp/uploads"
 update_log="${admin_dir}/log/update.log"
+percentage=0
 
 log_output() {
   tee -a "$update_log"
 }
 
 fail_and_exit() {
-  echo "failed" > "${admin_dir}/etc/status_update.txt"
+  update_status "failed"
+
   echo "[`date +%s`][{{ admin_type }}] Failed updating {{ admin_type_lowcase }}. Cleaning up.." | log_output
   exit 1
 }
@@ -44,6 +46,14 @@ cleanup() {
   rm -f /tmp/update_vm.sh.task
 }
 
+update_status() {
+  echo "{\"status\":\"${1}\",\"percentage\":${percentage}}" > "${admin_dir}/etc/status_update.json"
+  echo "$1" > "${admin_dir}/etc/status_update.txt"
+}
+
+touch ${admin_dir}/etc/status_update.txt
+chgrp 997 ${admin_dir}/etc/status_update.txt
+
 if [ -f "/tmp/update_vm.sh.task" ]; then
   log_error "Update is already running" "E1004"
 fi
@@ -53,6 +63,9 @@ echo "$$" > /tmp/update_vm.sh.task
 
 # Find the highest version package uploaded to the appliance
 find_latest_package() {
+  percentage=20
+  update_status "running"
+
   cd "${uploads_dir}"
 
   # Note: this requires GNU sort from coreutils
@@ -65,6 +78,9 @@ find_latest_package() {
 
 # Decrypt and extract the update package with the updates.key
 decrypt_software_package() {
+  percentage=30
+  update_status "running"
+
   cd "${admin_dir}/tmp"
 
   [ -d "update" ] || mkdir update
@@ -73,14 +89,23 @@ decrypt_software_package() {
   umask 027
   mv -f "${uploads_dir}/${latest_package}" "${admin_dir}/tmp/"
   { $openssl_cmd aes-256-cbc -d -pass file:"${admin_dir}/etc/updates.key" -in "$latest_package" | $tar_cmd -xf - -C extracted; } || log_error "Error decrypting software update package" "E1005"
+  percentage=40
+  update_status "running"
+
   rm -f "$latest_package"
   $openssl_cmd dgst -sha256 -verify "${admin_dir}/etc/updates.pub" -signature extracted/software_package.tar.gz.sign extracted/software_package.tar.gz  || log_error "Error verifying software update package signature" "E1005"
+  percentage=50
+  update_status "running"
+
   $tar_cmd --no-same-owner --no-same-permissions -zxf extracted/software_package.tar.gz -C update || log_error "Error extracting software update package" "E1005"
   rm -rf extracted
 }
 
 # Compare the server and package versions
 compare_versions() {
+  percentage=60
+  update_status "running"
+
   cd "${admin_dir}/tmp/update"
 
   # Only compare if both files exist
@@ -105,6 +130,9 @@ compare_versions() {
 
 # Update the {{ admin_type_lowcase }} and log the results
 update_appliance() {
+  percentage=70
+  update_status "running"
+
   cd "${admin_dir}/tmp/update"
 
   if [ -f "update.sh" ]; then
@@ -112,9 +140,14 @@ update_appliance() {
 
     chmod +x update.sh
     if ./update.sh; then
+      percentage=80
+      update_status "running"
+
       echo "Completed update at: `date`" | log_output
       return 0
     else
+      percentage=80
+
       if [ -f "${admin_dir}/etc/status_error_message.txt" ] && [ -f "${admin_dir}/etc/status_error_code.txt" ]; then
         fail_and_exit
       else
@@ -122,7 +155,9 @@ update_appliance() {
       fi
     fi
   else
-    echo "success" > "${admin_dir}/etc/status_update.txt"
+    percentage=90
+    update_status "success"
+
     echo "[`date +%s`][{{ admin_type }}] No update script found, skipping." | log_output
     exit 0
   fi
@@ -138,8 +173,10 @@ trap fail_and_exit SIGINT SIGTERM
 [ -f "$update_log" ] || touch "$update_log"
 chmod 664 "$update_log"
 chown 0:997 "$update_log"
-echo "running" > "${admin_dir}/etc/status_update.txt"
-chgrp 997 ${admin_dir}/etc/status_update.txt
+
+percentage=10
+update_status "running"
+
 echo "[`date +%s`][{{ admin_type }}] Updating {{ admin_type_lowcase }}. Please wait.." | log_output
 
 rm -f "${admin_dir}/etc/status_error_message.txt" "${admin_dir}/etc/status_error_code.txt"
@@ -149,6 +186,8 @@ decrypt_software_package  && \
 compare_versions          && \
 update_appliance          || log_error "Script error" "E1000"
 
-echo "success" > "${admin_dir}/etc/status_update.txt"
+percentage=100
+update_status "success"
+
 echo "[`date +%s`][{{ admin_type }}] Update successful" | log_output
 exit 0

--- a/roles/admin/templates/update_vm.sh.j2
+++ b/roles/admin/templates/update_vm.sh.j2
@@ -84,7 +84,7 @@ decrypt_software_package() {
   percentage=30
   update_status "running"
 
-  [ -d "${disk_dir}/tmp" ] || mkdir ${disk_dir}/tmp
+  [ -d "${disk_dir}/tmp" ] || mkdir -p ${disk_dir}/tmp
   [ -d "${disk_dir}/tmp/extracted" ] || mkdir ${disk_dir}/tmp/extracted
   [ -d "${admin_dir}/tmp/update" ] || mkdir ${admin_dir}/tmp/update
 

--- a/test.l
+++ b/test.l
@@ -1,0 +1,9 @@
+#!/usr/bin/env pil
+
+(load ".modules/picolisp-unit/HEAD/unit.l")
+
+(let bye nil # don't let (bye) spoil our fun
+  (chdir "tests/"
+    (load "test_tc-functions.l") ) )
+
+(report)

--- a/test.l
+++ b/test.l
@@ -1,6 +1,8 @@
 #!/usr/bin/env pil
 
-(load ".modules/picolisp-unit/HEAD/unit.l")
+(unless *Tc_functions_loaded
+  (chdir (pack (if (sys "JIDO_ADMIN_PATH") @ "/opt/jidoteki/tinyadmin") "/lib")
+    (load "tc-functions.l" ".modules/picolisp-unit/HEAD/unit.l") ) )
 
 (let bye nil # don't let (bye) spoil our fun
   (chdir "tests/"

--- a/tests/test_tc-functions.l
+++ b/tests/test_tc-functions.l
@@ -1,0 +1,118 @@
+(unless *Tc_functions_loaded (load (pack (car (file)) "../roles/admin/templates/tc-functions.l.j2")))
+
+(prinl "^J  Testing TinyCore scripts^J")
+
+(setq
+      *My_tests_are_order_dependent NIL )
+
+[de APP_INFO
+  ("name"      "test_tc-functions.l")
+  ("version"   "0.0.3")
+  ("summary"   "Unit tests'")
+  ("source"    "https://github.com/Jidoteki/tinycore-scripts")
+  ("author"    "Alexander Williams")
+  ("license"   "MIT")
+  ("copyright" "(c) 2016 Alexander Williams, Unscramble <license@unscramble.jp>") ]
+
+[de APP_HELP
+  ("usage"     "test.l")
+  ("example"   "test.l")
+  ("options"   ("--help"    "show this help message and exit")
+               ("--version" "show the application version and exit") ]
+
+[de error-codes
+  ("TC0001"     "Invalid command line argument") ]
+
+### tests
+
+[de test-functions-loaded ()
+  (assert-t             *Tc_functions_loaded
+                        "Ensure all functions are loaded only once" ]
+
+[de test-root-variable ()
+  (assert-equal         "/"
+                        *Root
+                        "Ensure the *Root variable points to /" ]
+
+[de test-tc-error-empty ()
+  (assert-equal         '(("File" . "test_tc-functions.l") ("Code") ("Message") ("Details"))
+                        (tc-error)
+                        "Ensure tc-error returns a list with empty values" ]
+
+[de test-tc-error-full ()
+  (assert-equal         '(("File" . "test_tc-functions.l") ("Code" . "TC0001") ("Message" . "Invalid command line argument") ("Details" . "--testing"))
+                        (tc-error "TC0001" "--testing")
+                        "Ensure tc-error returns a list with filled values" ]
+
+[de test-tc-error-stderr-empty ()
+  (assert-nil           (err "/dev/null" (tc-error-stderr))
+                        "Ensure tc-error-stderr returns nothing" ]
+
+[de test-tc-error-stderr-full ()
+  (assert-equal         "test_tc-functions.l: TC0001: Invalid command line argument: --testing"
+                        (err "/dev/null" (tc-error-stderr (tc-error "TC0001" "--testing")))
+                        "Ensure tc-error-stderr returns an error string" ]
+
+[de test-tc-error-json-full ()
+  (let Result
+                  "{\"File\":\"test_tc-functions.l\",\"Code\":\"TC0001\",\"Message\":\"Invalid command line argument\",\"Details\":\"--testing\"}"
+    (assert-equal       Result
+                        (err "/dev/null" (tc-error-generic (encode (tc-error "TC0001" "--testing"))))
+                        "Ensure tc-error-output returns an error string in JSON" ) ]
+
+[de test-tc-show-version-empty ()
+  (let APP_INFO NIL
+    (assert-equal         " v^JCopyright ^JLicense "
+                          (out "/dev/null" (tc-show-version))
+                          "Ensure tc-show-version returns an 'empty' string" ]
+
+[de test-tc-show-version-full ()
+  (assert-equal         "test_tc-functions.l v0.0.3^JCopyright (c) 2016 Alexander Williams, Unscramble <license@unscramble.jp>^JLicense MIT"
+                        (out "/dev/null" (tc-show-version))
+                        "Ensure tc-show-version returns version info" ]
+
+[de test-tc-show-options-empty ()
+  (let APP_HELP NIL
+    (assert-nil           (out "/dev/null" (tc-show-options))
+                          "Ensure tc-show-options returns an 'empty' string" ]
+
+[de test-tc-json-decode ()
+  (let Json "{\"test\":\"string\"}"
+    (assert-equal       (list (cons "test" "string"))
+                        (decode Json)
+                        "Ensure '(decode)' can decode a JSON string" ]
+
+[de test-tc-json-encode ()
+  (let Json (list (cons "test" "string"))
+    (assert-equal       "{\"test\":\"string\"}"
+                        (encode Json)
+                        "Ensure '(encode)' can encode a JSON string" ]
+
+[de test-tc-call-t ()
+  (assert-t           (tc-call (list 'true))
+                      "Ensure tc-call returns T when a command doesn't output to stderr" ]
+
+[de test-tc-call-nil ()
+  (assert-nil         (tc-call (list 'acommandthatdoesntexist))
+                      "Ensure tc-call returns NIL when a command outputs to stderr" ]
+
+[de test-tc-semver-satisfies ()
+  (assert-t           (semver-satisfies "1.0.0" "1.0.0" "2.0.0")
+                      "Ensure '(semver-satisfies)' can format, compare, sort a string") ]
+
+[execute
+  '(test-functions-loaded)
+  '(test-root-variable)
+  '(test-tc-error-empty)
+  '(test-tc-error-full)
+  '(test-tc-error-stderr-empty)
+  '(test-tc-error-stderr-full)
+  '(test-tc-show-version-empty)
+  '(test-tc-show-version-full)
+  '(test-tc-show-options-empty)
+  '(test-tc-json-decode)
+  '(test-tc-json-encode)
+  '(test-tc-error-json-full)
+  '(test-tc-call-t)
+  '(test-tc-call-nil)
+  '(test-tc-semver-satisfies) ]

--- a/tests/test_tc-functions.l
+++ b/tests/test_tc-functions.l
@@ -7,7 +7,7 @@
   ("name"      "test_tc-functions.l")
   ("version"   "0.0.3")
   ("summary"   "Unit tests'")
-  ("source"    "https://github.com/Jidoteki/tinycore-scripts")
+  ("source"    "https://github.com/on-prem/tinycore-scripts")
   ("author"    "Alexander Williams")
   ("license"   "MIT")
   ("copyright" "(c) 2016 Alexander Williams, Unscramble <license@unscramble.jp>") ]

--- a/tests/test_tc-functions.l
+++ b/tests/test_tc-functions.l
@@ -1,5 +1,3 @@
-(unless *Tc_functions_loaded (load (pack (car (file)) "../roles/admin/templates/tc-functions.l.j2")))
-
 (prinl "^J  Testing TinyCore scripts^J")
 
 (setq


### PR DESCRIPTION
Merge the `jidometa-scripts` repo along with its tests, which now includes the `json, semver, unit` libraries by default.